### PR TITLE
Ignore the number of line breaks in texts to compare in test fixtures

### DIFF
--- a/test/epub-searcher/database_test.rb
+++ b/test/epub-searcher/database_test.rb
@@ -59,8 +59,9 @@ class TestDatabase < Test::Unit::TestCase
       dumped_text = `#{dump_command}`.gsub(%r|/.+?/test/epub-searcher/fixtures/|) do
         "${PREFIX}/test/epub-searcher/fixtures/"
       end
+      dumped_text.gsub!(/(?:\\r\\n)+/, "\\r\\n")
 
-      expected = File.read(fixture_path('loaded_records_dump_expected.txt'))
+      expected = File.read(fixture_path('loaded_records_dump_expected.txt')).gsub!(/(?:\\r\\n)+/, "\\r\\n")
       assert_equal(expected, dumped_text)
     end
   end

--- a/test/epub-searcher/epub_document_test.rb
+++ b/test/epub-searcher/epub_document_test.rb
@@ -27,8 +27,9 @@ class TestEPUBDocument < Test::Unit::TestCase
   end
 
   def assert_equal_main_text(expected_file, document)
-    expected_text = File.read(fixture_path(expected_file))
-    assert_equal(expected_text, document.extract_main_text)
+    expected_text = File.read(fixture_path(expected_file)).gsub(/(?:\r\n)+/, "\r\n")
+    main_text = document.extract_main_text.gsub(/(?:\r\n)+/, "\r\n")
+    assert_equal(expected_text, main_text)
   end
 
   def assert_equal_xhtml_spine(expected, document)

--- a/test/epub-searcher/remote_database_test.rb
+++ b/test/epub-searcher/remote_database_test.rb
@@ -62,12 +62,13 @@ class TestRemoteDatabase < Test::Unit::TestCase
       expected_values = File.read(fixture_path('load_records_params_values_expected.txt'))
       expected = {
         :table => :Books,
-        :values => expected_values,
+        :values => expected_values.gsub(/(?:(\\r\\n)+)/, "\\r\\n"),
       }
       @database.client.expects(:load).with do |actual_params|
         actual_params[:values].gsub!(%r|"file_path":"/.+?/test/epub-searcher/fixtures/|) do
           "\"file_path\":\"${PREFIX}/test/epub-searcher/fixtures/"
         end
+        actual_params[:values].gsub!(/(?:\\r\\n)+/, "\\r\\n")
         expected == actual_params
       end
 


### PR DESCRIPTION
こんにちは。

かつてはテストが通っていたようなのですが、Nokogiriのバージョンが1.6.3.1に上がった今では、通らなくなってしまっていました。
（TravisによるとNokogiri 1.6.0の頃は大丈夫だったようです： https://travis-ci.org/ranguba/epub-searcher/builds/9336960）

そこで、通るようにテストの方を修正してみました。
厳密に、テストフィクスチャーを修正してもよかったのですが、改行の数が本質的ではないように見えたので、数を無視する方向で修正しました。
もし、フィクスチャーを直すべきということでしたら言ってください。直します。

ご検討よろしくお願いします。
